### PR TITLE
Adding ServerFarmId in upload certificate

### DIFF
--- a/AzureLetsEncrypt/SharedFunctions.cs
+++ b/AzureLetsEncrypt/SharedFunctions.cs
@@ -234,7 +234,8 @@ namespace AzureLetsEncrypt
             {
                 Location = site.Location,
                 Password = "P@ssw0rd",
-                PfxBlob = pfxBlob
+                PfxBlob = pfxBlob,
+                ServerFarmId = site.ServerFarmId
             });
         }
 


### PR DESCRIPTION
Fixed an issue that would cause an error when Web App and Service Plan was in different resource groups.

Ref #9 